### PR TITLE
Add support for custom User models.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 dev-env: dev-env/bin/activate
 dev-env/bin/activate: dev_requirements.txt clean
 	test -d dev-env || virtualenv dev-env
-	. dev-env/bin/activate; pip install -Ur requirements.txt
+	. dev-env/bin/activate; pip install -Ur dev_requirements.txt
 
 clean:
 	- find . -type f -name "*.pyc" -delete

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,6 @@
 Django>=1.4
 django-appconf==0.6
+docopt==0.6.1
 # For compatibility reasons, all migrations must be generated with South==0.7.6
 South==0.7.6
+

--- a/djoauth2/migrations/0001_initial.py
+++ b/djoauth2/migrations/0001_initial.py
@@ -5,19 +5,30 @@ from south.v2 import SchemaMigration
 from django.db import models
 
 
+try:
+    from django.contrib.auth import get_user_model
+except ImportError: # django < 1.5
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
+
+user_orm_label = '%s.%s' % (User._meta.app_label, User._meta.object_name)
+user_model_label = '%s.%s' % (User._meta.app_label, User._meta.module_name)
+user_ptr_name = '%s_ptr' % User._meta.object_name.lower()
+
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
         # Adding model 'Client'
         db.create_table('djoauth2_client', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'])),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm[user_orm_label])),
             ('name', self.gf('django.db.models.fields.CharField')(max_length=256)),
             ('description', self.gf('django.db.models.fields.TextField')(null=True, blank=True)),
             ('image_url', self.gf('django.db.models.fields.URLField')(max_length=200, null=True, blank=True)),
             ('redirect_uri', self.gf('django.db.models.fields.URLField')(max_length=200)),
-            ('key', self.gf('django.db.models.fields.CharField')(default='fZhQXI_GsinrAl7x~.duMTvkm5SbCV', unique=True, max_length=30, db_index=True)),
-            ('secret', self.gf('django.db.models.fields.CharField')(default='CYQIBm6dEKA-G_5F0R9Ho~ZMqp1jvO', unique=True, max_length=30, db_index=True)),
+            ('key', self.gf('django.db.models.fields.CharField')(default='yZ5I9rdUWJmdtC_L8ZX6iSenXSqbxl', unique=True, max_length=30, db_index=True)),
+            ('secret', self.gf('django.db.models.fields.CharField')(default='lycb4P-ehpWZf1Sm12YCAdPjzZgpzM', unique=True, max_length=30, db_index=True)),
         ))
         db.send_create_signal('djoauth2', ['Client'])
 
@@ -33,12 +44,12 @@ class Migration(SchemaMigration):
         db.create_table('djoauth2_authorizationcode', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('client', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['djoauth2.Client'])),
-            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'])),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm[user_orm_label])),
             ('date_created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
             ('lifetime', self.gf('django.db.models.fields.PositiveIntegerField')(default=600)),
             ('invalidated', self.gf('django.db.models.fields.BooleanField')(default=False)),
             ('redirect_uri', self.gf('django.db.models.fields.URLField')(max_length=200, null=True, blank=True)),
-            ('value', self.gf('django.db.models.fields.CharField')(default='VaQofWvI7HRUNF4x1Ls8TMpu9bh2~j', unique=True, max_length=30, db_index=True)),
+            ('value', self.gf('django.db.models.fields.CharField')(default='UeM_JTC6Hbv_rwtUxb_3TelYebAjRv', unique=True, max_length=30, db_index=True)),
         ))
         db.send_create_signal('djoauth2', ['AuthorizationCode'])
 
@@ -59,9 +70,9 @@ class Migration(SchemaMigration):
             ('invalidated', self.gf('django.db.models.fields.BooleanField')(default=False)),
             ('authorization_code', self.gf('django.db.models.fields.related.ForeignKey')(blank=True, related_name='access_tokens', null=True, to=orm['djoauth2.AuthorizationCode'])),
             ('refreshable', self.gf('django.db.models.fields.BooleanField')(default=True)),
-            ('refresh_token', self.gf('django.db.models.fields.CharField')(null=True, default='EsmhYxg1bfXI20zJ93FvBSriu5UH4j', max_length=30, blank=True, unique=True, db_index=True)),
-            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'])),
-            ('value', self.gf('django.db.models.fields.CharField')(default='CnK9NrzHYOV5_E0Xe8WmGjSkv3q4Mi', unique=True, max_length=30, db_index=True)),
+            ('refresh_token', self.gf('django.db.models.fields.CharField')(null=True, default='~FQ9BP_AkyfigsQtgoGjpBuS6GiKmz', max_length=30, blank=True, unique=True, db_index=True)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm[user_orm_label])),
+            ('value', self.gf('django.db.models.fields.CharField')(default='h.05aDeU63RiLv7P2QYkf0sm7qMn0a', unique=True, max_length=30, db_index=True)),
         ))
         db.send_create_signal('djoauth2', ['AccessToken'])
 
@@ -108,8 +119,8 @@ class Migration(SchemaMigration):
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
-        'auth.user': {
-            'Meta': {'object_name': 'User'},
+        user_model_label: {
+            'Meta': {'object_name': User.__name__, 'db_table': "'%s'" % User._meta.db_table},
             'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
@@ -139,11 +150,11 @@ class Migration(SchemaMigration):
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'invalidated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'lifetime': ('django.db.models.fields.PositiveIntegerField', [], {'default': '3600'}),
-            'refresh_token': ('django.db.models.fields.CharField', [], {'null': 'True', 'default': "'dypx1aPg9hQtv7b8R43kn6cqV~EFHN'", 'max_length': '30', 'blank': 'True', 'unique': 'True', 'db_index': 'True'}),
+            'refresh_token': ('django.db.models.fields.CharField', [], {'null': 'True', 'default': "'Pj2nbBrHZxXcLEKZ82aa41LZncZ_Hy'", 'max_length': '30', 'blank': 'True', 'unique': 'True', 'db_index': 'True'}),
             'refreshable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'scopes': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'access_tokens'", 'symmetrical': 'False', 'to': "orm['djoauth2.Scope']"}),
-            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
-            'value': ('django.db.models.fields.CharField', [], {'default': "'mB9DAWsItGpFOC~T6af1o4geiR7lHK'", 'unique': 'True', 'max_length': '30', 'db_index': 'True'})
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['%s']" % user_orm_label}),
+            'value': ('django.db.models.fields.CharField', [], {'default': "'kxIgLeiD3wDtVTRUHkGOUGcwcA5mQs'", 'unique': 'True', 'max_length': '30', 'db_index': 'True'})
         },
         'djoauth2.authorizationcode': {
             'Meta': {'object_name': 'AuthorizationCode'},
@@ -154,19 +165,19 @@ class Migration(SchemaMigration):
             'lifetime': ('django.db.models.fields.PositiveIntegerField', [], {'default': '600'}),
             'redirect_uri': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
             'scopes': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'authorization_codes'", 'symmetrical': 'False', 'to': "orm['djoauth2.Scope']"}),
-            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
-            'value': ('django.db.models.fields.CharField', [], {'default': "'TfOsDkoZr.ley9NzYPuX~IEAQc4aK1'", 'unique': 'True', 'max_length': '30', 'db_index': 'True'})
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['%s']" % user_orm_label}),
+            'value': ('django.db.models.fields.CharField', [], {'default': "'5bvTZ30typOO~JbOKLW8Y_bO05AQaq'", 'unique': 'True', 'max_length': '30', 'db_index': 'True'})
         },
         'djoauth2.client': {
             'Meta': {'object_name': 'Client'},
             'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'image_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
-            'key': ('django.db.models.fields.CharField', [], {'default': "'~ozx3OEg4qHt_-jXi.ubarMdB6RfV1'", 'unique': 'True', 'max_length': '30', 'db_index': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'default': "'nA2O8uJKGenq-0xFZi-4_Nqe62WOmK'", 'unique': 'True', 'max_length': '30', 'db_index': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
             'redirect_uri': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
-            'secret': ('django.db.models.fields.CharField', [], {'default': "'SARM5tag_qQunmovi-VJHs2Nz3GdbO'", 'unique': 'True', 'max_length': '30', 'db_index': 'True'}),
-            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+            'secret': ('django.db.models.fields.CharField', [], {'default': "'NVi54-W98FBsVFr7FFcL_yaM5CRjXy'", 'unique': 'True', 'max_length': '30', 'db_index': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['%s']" % user_orm_label})
         },
         'djoauth2.scope': {
             'Meta': {'object_name': 'Scope'},

--- a/djoauth2/models.py
+++ b/djoauth2/models.py
@@ -2,7 +2,6 @@
 from datetime import datetime
 from datetime import timedelta
 
-from django.contrib.auth.models import User
 from django.db import models
 from django.utils.timezone import now
 
@@ -12,9 +11,10 @@ from djoauth2.helpers import make_bearer_token
 from djoauth2.helpers import make_client_key
 from djoauth2.helpers import make_client_secret
 
+UserModel = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 class Client(models.Model):
-  user = models.ForeignKey(User)
+  user = models.ForeignKey(UserModel)
   name = models.CharField(max_length=256)
   description = models.TextField(null=True, blank=True)
   image_url = models.URLField(null=True, blank=True)
@@ -52,7 +52,7 @@ class Scope(models.Model):
 
 class AuthorizationCode(models.Model):
   client = models.ForeignKey(Client)
-  user = models.ForeignKey(User)
+  user = models.ForeignKey(UserModel)
   date_created = models.DateTimeField(auto_now_add=True)
   lifetime = models.PositiveIntegerField(
       default=lambda: settings.DJOAUTH2_AUTHORIZATION_CODE_LIFETIME)
@@ -108,7 +108,7 @@ class AccessToken(models.Model):
     unique=True,
   )
   scopes = models.ManyToManyField(Scope, related_name='access_tokens')
-  user = models.ForeignKey(User)
+  user = models.ForeignKey(UserModel)
   value = models.CharField(
     db_index=True,
     default=make_bearer_token(settings.DJOAUTH2_ACCESS_TOKEN_LENGTH),

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -71,6 +71,11 @@ Install the models:
   python manage.py syncdb
   python manage.py migrate djoauth2
 
+In Django 1.5+, ``djoauth2`` will respect `your custom User model`_ if you have
+one configured (with the `AUTH_USER_MODEL`_ setting.) In Django 1.4, or 1.5+ if
+you're not using a custom User model, the ``djoauth2`` models will link to the
+``django.contrib.auth.models.User`` object.
+
 Run the tests — they should all pass!
 
 .. code-block:: bash
@@ -388,5 +393,6 @@ then you must begin again by redirecting the user to the authorization page.
   
 .. _`Django AppConf`: https://github.com/jezdez/django-appconf
 .. _`South`: http://south.aeracode.org/
+.. _`your configured custom User model`: https://docs.djangoproject.com/en/dev/topics/auth/customizing/#substituting-a-custom-user-model
 .. _`a finished example`: https://github.com/Locu/djoauth2/tree/master/example
 .. _`check it out`: https://github.com/Locu/djoauth2/blob/master/example/client_demo.py

--- a/generate_migrations.py
+++ b/generate_migrations.py
@@ -17,6 +17,8 @@ import local_settings
 # missing or badly-configured settings.
 from django.core import management
 
+from refactor_migrations import refactor
+
 
 def generate_migrations(initial):
   management.call_command('syncdb', interactive=False)
@@ -24,6 +26,8 @@ def generate_migrations(initial):
     management.call_command('schemamigration', 'djoauth2', initial=True)
   else:
     management.call_command('schemamigration', 'djoauth2', auto=True)
+  refactor('./djoauth2/migrations/')
+
 
 def test_migrations():
   management.call_command('syncdb', interactive=False)

--- a/refactor_migrations.py
+++ b/refactor_migrations.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Refactor South migrations to use settings.AUTH_USER_MODEL.
+Inserts a backwards-compatible code-snippet in all
+your schema migration files and uses a possibly customized user
+model as introduced in Django 1.5.
+
+Please note that this has nothing to do with changing
+settings.AUTH_USER_MODEL to a new model. If you do this, stuff
+will very likely break in reusable apps that have their own
+migration trees.
+
+Attributions:
+github "benjaoming" this script
+
+github "rockymeza" for this commit which held the ingredients:
+https://github.com/fusionbox/mezzanine/commit/a9ea14719ad70ef2c92b26162eb3ae90283dbea2
+
+Stackexchange Q&A:
+http://stackoverflow.com/questions/15472704/trouble-migrating-reusable-django-app-models-to-use-a-custom-user-model
+
+Usage:
+  custom_user_auth_south_refactor.py <migration-dir>
+  custom_user_auth_south_refactor.py (-h | --help)
+  custom_user_auth_south_refactor.py --version
+
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+
+"""
+from docopt import docopt
+import os
+import re
+
+RE_CLASS_NAME = re.compile(r'^()^(class\s+Migration\s*\(\s*(SchemaMigration|DataMigration)\s*\)\s*:)',
+    re.MULTILINE)
+
+INSERT_AT_TOP_OF_MIGRATION = """try:
+    from django.contrib.auth import get_user_model
+except ImportError: # django < 1.5
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
+
+user_orm_label = '%s.%s' % (User._meta.app_label, User._meta.object_name)
+user_model_label = '%s.%s' % (User._meta.app_label, User._meta.module_name)
+user_ptr_name = '%s_ptr' % User._meta.object_name.lower()
+
+"""
+RE_FK_LABEL = re.compile(r"to\=orm\[u?\'auth\.User\'\]")
+RE_FK_LABEL_TO = "to=orm[user_orm_label]"
+
+RE_FK_BACKWARDS = re.compile(r"'to':\s*u?\"orm\['auth\.User'\]\"")
+RE_FK_BACKWARDS_TO = "'to': \"orm['%s']\" % user_orm_label"
+
+RE_AUTH_MODEL = re.compile(r"u?'auth\.user'\:\s*\{")
+RE_AUTH_MODEL_TO = r"user_model_label: {"
+
+RE_AUTH_PTR_FIELD = re.compile(r"u?'user_ptr'(.+to=orm\['auth.User)")
+RE_AUTH_PTR_FIELD_TO = "user_ptr_name\\1"
+
+RE_ORM_BASES = re.compile(r"u?'_ormbases':\s*\[u?'auth.User'\]")
+RE_ORM_BASES_TO = r"'_ormbases': [user_orm_label]"
+
+RE_META_STRING = re.compile(r"u?'Meta':\s*\{\s*u?'object_name'\s*:\s*u?'User'\s*\}")
+RE_META_TO = "'Meta': {'object_name': User.__name__, 'db_table': \"'%s'\" % User._meta.db_table}"
+
+RE_TEST_OK = re.compile(r"'auth.User'", re.IGNORECASE)
+
+RE_MIGRATION_FNAME = re.compile(r"^(\d{4}).+py$")
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__, version='1.0')
+    migration_dir = arguments['<migration-dir>']
+    for fname in os.listdir(migration_dir):
+        if not RE_MIGRATION_FNAME.search(fname):
+            continue
+        full_path = os.path.join(migration_dir, fname)
+        f = open(full_path, 'r')
+        contents = f.read()
+        f.close()
+        if RE_FK_LABEL.search(contents) or RE_META_STRING.search(contents) or RE_AUTH_MODEL.search(contents) or RE_FK_LABEL.search(contents):
+            print "Refactoring {0}".format(fname)
+            f = open(full_path, 'w')
+            contents = RE_CLASS_NAME.sub(INSERT_AT_TOP_OF_MIGRATION + r"\2",
+                contents)
+            contents = RE_AUTH_PTR_FIELD.sub(RE_AUTH_PTR_FIELD_TO, contents)
+            contents = RE_AUTH_MODEL.sub(RE_AUTH_MODEL_TO, contents)
+            contents = RE_META_STRING.sub(RE_META_TO, contents)
+            contents = RE_FK_BACKWARDS.sub(RE_FK_BACKWARDS_TO, contents)
+            contents = RE_ORM_BASES.sub(RE_ORM_BASES_TO, contents)
+            contents = RE_FK_LABEL.sub(RE_FK_LABEL_TO, contents)
+            f.write(contents)
+            f.close()
+        else:
+            print "Skipping {0}".format(fname)
+        if RE_TEST_OK.search(contents):
+            print "    WARNING! Still found occurrences of auth.User. Fix manually!"


### PR DESCRIPTION
Django 1.5+ supports a configurable User model, instead of forcing developers to use `django.contrib.auth.models.User`. Until now, `djoauth2` has explicitly linked to `django.contrib.auth.models.User`, which means that developers with custom User models could not use this library.

This diffset:
- Updates the `djoauth2` models to look for the configured User model, not just `django.contrib.auth.models.User`.
- Updates the existing migration file (`0001_initial.py`) to use the configured User model in Django 1.5+, while still remaining equivalent to the previous version when used in Django 1.4.
- Updates the `generate_migrations.py` script to automatically refactor any generated migrations to maintain this compatibility, instead of forcing developers to do this by hand. Big thanks to @Benjaoming for [the original version of the refactoring script](https://gist.github.com/benjaoming/5605160), which I've updated slightly in order to make it easier to call from other Python code.
- Fixes a bug where the production (not development) requirements were being installed in the development virtual env created by `make dev-env`.

This diffset _does not_ contain any tests because I'm not sure how to test this sort of migration change. Using the example application locally I've been able to verify that the code works as I expect, but it would be great to do this in an automated way. Contributions welcome!

One other thing to know: this change _will break_ `djoauth2` for developers with custom user models who previously installed `djoauth2`. Their databases have been migrated such that the `djoauth2` models point to `django.contrib.auth.models.User`, but this diff changes the migration to point to their configurable model.  I suspect that no users are in this situation but at the same time I want to make it known that this could be an issue.
